### PR TITLE
adds vm state to observations

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -6,6 +6,10 @@ num_vms_per_env: 100
 action_masking: True
 vectorize_environment: False
 
+# STATE
+# currently only adds the state of the first VM to the observation. Therefore, it makes sense to set num_vms_per_env to 1 if add_vm_state_to_observations is set to True
+add_vm_state_to_observations: False
+
 # REWARDs
 only_reward_on_ret: False
 punish_cap: 24

--- a/src/args.py
+++ b/src/args.py
@@ -17,6 +17,9 @@ class GlobalArgs(Serializable):
     num_envs: int = 16  # NOTE(rob2u): automatically set to 1 if not vectorized
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
 
+    # STATE
+    add_vm_state_to_observations: bool = False
+
     # ENVIRONMENT -- GRAPH Generation
     num_vms_per_env: int = 100
     min_n: int = 3

--- a/src/environment/environment.py
+++ b/src/environment/environment.py
@@ -315,6 +315,8 @@ class MSTCodeEnvironment(gym.Env[npt.ArrayLike, int]):
 
         # NOTE(rob2u): might be worth trying to parse the entire state of the VM (as above)
         if code:
+            assert len(code) <= self.max_code_length, "Code too long! Make sure other state variables are not part of the code."
+
             vm_observation = np.zeros(3)
             code_filler = [0] * (self.max_code_length - len(code))
             observation = np.concatenate(

--- a/src/sweep.py
+++ b/src/sweep.py
@@ -10,9 +10,9 @@ import wandb
 
 sweep_config = {
     "program": "src/train.py",
-    "name": "always_reward",
+    "name": "vm-observations-in-state",
     "method": "bayes",
-    "metric": {"goal": "maximize", "name": "best_reward_avg"},
+    "metric": {"goal": "maximize", "name": "best_end_reward"},
     "parameters": {
         "config_path": {
             "values": ["configs/config.yaml"],

--- a/src/train.py
+++ b/src/train.py
@@ -103,6 +103,11 @@ if __name__ == "__main__":
         parse(GlobalArgs, config_path=config_path)
     )  # if config_path is set, default values are loaded from there and overwritten by the command line arguments
 
+    observation_size = global_args["max_code_length"]
+    if global_args["add_vm_state_to_observations"]:
+        observation_size += 3  # add 3 more dimensions for the VM state
+    global_args["observation_size"] = observation_size
+
     # Setup WandB:
     wandb_run = wandb.init(
         entity="na_mst_2",
@@ -131,7 +136,7 @@ if __name__ == "__main__":
     nhead = global_args["fe_nhead"]
     num_blocks = global_args["fe_num_blocks"]
     num_instructions = len(COMMAND_REGISTRY)
-    program_length = global_args["max_code_length"]
+
     layer_dim_pi = global_args["layer_dim_pi"]
     layer_dim_vf = global_args["layer_dim_vf"]
 
@@ -143,7 +148,7 @@ if __name__ == "__main__":
             nhead=nhead,
             num_blocks=num_blocks,
             num_instructions=num_instructions,
-            program_length=program_length,
+            observation_size=observation_size,
             device=global_args["device"],
         ),
         # MLP layers for actor and critic after the transformer:

--- a/src/train.py
+++ b/src/train.py
@@ -75,6 +75,12 @@ def execute_program(
     return rewards, metrics
 
 
+def get_code_from_state(env_args: Dict[str, Any], state: List[int]) -> List[Type[AbstractCommand]]:
+    code_size = env_args["max_code_length"]
+    code = state[-code_size:]
+    return Transpiler.intToCommand([int(a) for a in code])  # type: ignore
+
+
 def infer_program(env_args: Dict[str, Any], model: Any) -> List[Type[AbstractCommand]]:
     new_env: Env[Any, Any] = gym.make("MSTCode-v0", **env_args)
     state, _ = new_env.reset()
@@ -87,7 +93,7 @@ def infer_program(env_args: Dict[str, Any], model: Any) -> List[Type[AbstractCom
         # logging.info(Transpiler.intToCommand([action])[0]())  # type: ignore
 
     new_env.close()  # type: ignore
-    return Transpiler.intToCommand([int(a) for a in state])  # type: ignore
+    return get_code_from_state(env_args, state)  # type: ignore
 
 
 def seed_all(seed: int = 42) -> None:


### PR DESCRIPTION
we add 3 further numbers to the observation by adding values ONLY from the first VM:
- 0/1 if the edge register contains a value
- 0-n for the number of edges in the edge set
- 0-n for the number of edges in the edge stack
This means we increase our observation space by 3 further values. To have the same dimensions across each state dimension we add a categorical value of the same size as the CODE_REGISTRY.

Therefore there are two open questions:
1. how to add values from several VMs
2. how to add a space state of different sizes (e.g. edge register only contains 0 or 1)

its configurable via `add_vm_state_to_observations`